### PR TITLE
Исправление критического бага в обертке WSServer

### DIFF
--- a/server/definitions.js
+++ b/server/definitions.js
@@ -11,7 +11,7 @@ const server = http.createServer(app)
 const staticRouter = express.Router()
 const apiRouter = express.Router()
 
-const wss = new WSServer(new ws.Server({server}))
+const wss = new WSServer(server)
 
 const logger = new Logger([{
   levels: [logLevels.DEBUG],

--- a/server/ws/handlers/message/endpoints/createMessage.js
+++ b/server/ws/handlers/message/endpoints/createMessage.js
@@ -1,11 +1,11 @@
+const WSError = require('../../../../misc/WSError')
 const {sendDataToClients} = require('../../../../misc/utils')
 const {checkUserHasAccessToConversation} = require('../../../services/conversation')
 const {saveMessage} = require('../../../services/messages')
 const {getConversationWithLastMessage} = require('../../../services/conversation')
-const {wrapAsyncFunction} = require('../../../../misc/utils')
 
 
-module.exports = wrapAsyncFunction(async (context, payload) => {
+module.exports = async (context, payload) => {
   const user = context.current.user
   const {conversationId, contentType, content, files} = payload.meta
 
@@ -15,8 +15,8 @@ module.exports = wrapAsyncFunction(async (context, payload) => {
 
   const conversation = await getConversationWithLastMessage(user, conversationId)
 
-  await sendDataToClients(context, {
+  await sendDataToClients(context.clients, {
     ...conversation,
     notificationType: 'newMessage'
   })
-})
+}

--- a/server/ws/handlers/message/endpoints/editMessage.js
+++ b/server/ws/handlers/message/endpoints/editMessage.js
@@ -6,7 +6,7 @@ const {checkUserHasAccessToConversation} = require('../../../services/conversati
 const {wrapAsyncFunction} = require('../../../../misc/utils')
 
 
-module.exports = wrapAsyncFunction(async (context, payload) => {
+module.exports = async (context, payload) => {
   const user = context.current.user
   const {conversationId, relativeId, content} = payload.meta
 
@@ -15,8 +15,8 @@ module.exports = wrapAsyncFunction(async (context, payload) => {
   const message = await editMessage(conversationId, relativeId, content)
 
   const sessions = (await getConversationParticipants(conversationId))
-                      .flatMap(participant => participant.sessions)
-                      .map(session => session.sessionId)
+  .flatMap(participant => participant.sessions)
+  .map(session => session.sessionId)
 
   const clients = context.clients.filter(client =>
       sessions.includes(client.session.sessionId)
@@ -34,5 +34,4 @@ module.exports = wrapAsyncFunction(async (context, payload) => {
       generationTimestamp: new Date().toISOString()
     }
   })
-
-})
+}

--- a/server/ws/handlers/message/endpoints/getAllConversations.js
+++ b/server/ws/handlers/message/endpoints/getAllConversations.js
@@ -2,10 +2,10 @@ const {getConversationsWithLastMessage} = require('../../../services/conversatio
 const {wrapAsyncFunction} = require('../../../../misc/utils')
 
 
-module.exports = wrapAsyncFunction(async (context, payload) => {
+module.exports = async (context, payload) => {
   const user = context.current.user
 
   const conversations = await getConversationsWithLastMessage(user)
 
   context.socket.answer(conversations)
-})
+}

--- a/server/ws/handlers/message/endpoints/getConversation.js
+++ b/server/ws/handlers/message/endpoints/getConversation.js
@@ -2,7 +2,7 @@ const {getConversationsWithMessages} = require('../../../services/conversation')
 const {wrapAsyncFunction} = require('../../../../misc/utils')
 
 
-module.exports = wrapAsyncFunction(async (context, payload) => {
+module.exports = async (context, payload) => {
   const {conversationId, relativeId} = payload.meta
   const user = context.current.user
 
@@ -12,5 +12,5 @@ module.exports = wrapAsyncFunction(async (context, payload) => {
   })
 
   return context.socket.answer(conversation)
-})
+}
 

--- a/server/ws/handlers/message/endpoints/getUser.js
+++ b/server/ws/handlers/message/endpoints/getUser.js
@@ -1,11 +1,11 @@
 const {wrapAsyncFunction} = require('../../../../misc/utils')
 
 
-module.exports = wrapAsyncFunction(async (context, payload) => {
+module.exports = async (context, payload) => {
     const user = context.current.user
 
     const userObject = user.toJSON()
     delete userObject.createdAt
 
     context.socket.answer(userObject)
-})
+}

--- a/server/ws/handlers/message/modifier.js
+++ b/server/ws/handlers/message/modifier.js
@@ -15,6 +15,7 @@ wss.onMessage((context, data, next) => {
   }
 
   const id = parsed.$id
+
   if (!Number.isInteger(id)) {
     throw new WSError('Сообщение должно содержать свойство $id')
   }
@@ -25,9 +26,6 @@ wss.onMessage((context, data, next) => {
 })
 
 function addMethod(socket, id) {
-  if (socket.answer) {
-    return
-  }
   socket.answer = (data, options, callback) => {
     let payload
     try {

--- a/server/ws/handlers/preConnection.js
+++ b/server/ws/handlers/preConnection.js
@@ -6,7 +6,7 @@ const WSError = require("../../misc/WSError");
 const {getUser} = require("../services/user");
 
 
-wss.onConnection(wrapAsyncFunction(async (context) => {
+wss.onPreConnection(wrapAsyncFunction(async context => {
   const request = context.request
   request.cookies = cookie.parse(request.headers.cookie || '')
 
@@ -22,8 +22,4 @@ wss.onConnection(wrapAsyncFunction(async (context) => {
     user,
     session
   }
-
-  context.clients.push({
-    session, socket: context.socket
-  })
 }))


### PR DESCRIPTION
Из-за асинхронности обработчиков события `connection`  сообщения, пришедшие до завершения работы этих обработчиков, пропускались и никак не обрабатывались